### PR TITLE
cryptolog: Fix manual update signature function to be callable from API

### DIFF
--- a/attachment.py
+++ b/attachment.py
@@ -7,6 +7,7 @@ from trytond.pool import PoolMeta, Pool
 from trytond.model import fields
 from trytond.pyson import Eval
 from trytond.transaction import Transaction
+from trytond.model import ModelView, fields
 
 __all__ = [
     'Attachment',
@@ -36,6 +37,12 @@ class Attachment(metaclass=PoolMeta):
         'cryptolog_get_documents')
 
     @classmethod
+    def __setup__(cls):
+        cls._buttons.update({
+                'cryptolog_update_transaction_info': {},
+                })
+
+    @classmethod
     def __register__(cls, module_name):
         TableHandler = backend.get('TableHandler')
         attachment_h = TableHandler(cls)
@@ -62,6 +69,8 @@ class Attachment(metaclass=PoolMeta):
         attachment_h.drop_column('cryptolog_url')
         attachment_h.drop_column('cryptolog_signer')
 
+    @classmethod
+    @ModelView.button
     def cryptolog_update_transaction_info(cls, attachments):
         signatures = [a.signature for a in attachments if a.signature]
         Pool().get('document.signature').update_transaction_info(signatures)

--- a/doc/en/CHANGELOG
+++ b/doc/en/CHANGELOG
@@ -1,3 +1,4 @@
+* BUG#16048 Fix electronic signature manual update function to be callable from API
 * FEA#14763 Allow to call electronic signature provider in two passes
 * BUG#12132 Crytpolog_data field is not correctly encoded
 * BUG#8586 Fix signer data's informations sent to universign

--- a/doc/fr/CHANGELOG
+++ b/doc/fr/CHANGELOG
@@ -1,3 +1,4 @@
+* BUG#16048 Correctif de la méthode de mise à jours des données de signature éléctronique afin d'être appelable depuis API.
 * FEA#14763 Possibilité de découper le procecssus de signature électronique en deux étape
 * BUG#12132 Le champ cryptolog_data n'est pas correctement encodé
 * BUG#8586 Correctif des données envoyées a universign concernant les informations du signataire


### PR DESCRIPTION
TO UPPORT

Fix #16048